### PR TITLE
Update Promise.swift

### DIFF
--- a/KinUtil/KinUtil/source/Promise.swift
+++ b/KinUtil/KinUtil/source/Promise.swift
@@ -174,7 +174,7 @@ extension Promise {
 
 extension Promise {
     private func run(_ block: () -> (), on queue: DispatchQueue?) {
-        if let queue = queue {
+        if let queue = queue, queue != .main {
             queue.sync { block() }
         }
         else {


### PR DESCRIPTION
Using `sync` on main queue crashes as invalid operation. This protects against `somePromise.then(on: .main) { ...` used already on main.